### PR TITLE
feat: ProviderMatches table + release-availability API (switcher foundation)

### DIFF
--- a/api/src/contracts/media.ts
+++ b/api/src/contracts/media.ts
@@ -98,6 +98,35 @@ export interface AlbumVersionContract extends SimilarAlbumContract {
   spatial_quality?: string | null;
 }
 
+export interface ReleaseAvailabilityProviderContract {
+  provider: string;
+  providerAlbumId: string | null;
+  quality: string | null;
+  librarySlot: string | null;
+  status: string | null;
+  confidence: number | null;
+}
+
+export interface ReleaseAvailabilityContract {
+  releaseMbid: string;
+  title: string | null;
+  disambiguation: string | null;
+  status: string | null;
+  date: string | null;
+  country: string | null;
+  format: string | null;
+  mediumCount: number | null;
+  trackCount: number | null;
+  duration: number | null;
+  availability: ReleaseAvailabilityProviderContract[];
+}
+
+export interface ReleaseGroupAvailabilityContract {
+  releaseGroupMbid: string;
+  selectedReleaseBySlot: Record<string, string | null>;
+  releases: ReleaseAvailabilityContract[];
+}
+
 export interface VideoDetailContract {
   id: string;
   title: string;
@@ -253,6 +282,52 @@ export function parseSimilarAlbumsContract(value: unknown): SimilarAlbumContract
 
 export function parseAlbumVersionsContract(value: unknown): AlbumVersionContract[] {
   return expectArray(value, "Album versions", (item, index) => parseAlbumListItemContract<AlbumVersionContract>(item, index));
+}
+
+function parseReleaseAvailabilityProviderContract(value: unknown, indexLabel: string): ReleaseAvailabilityProviderContract {
+  const record = expectRecord(value, indexLabel);
+  return {
+    provider: expectString(record.provider, `${indexLabel}.provider`),
+    providerAlbumId: expectNullableString(record.providerAlbumId, `${indexLabel}.providerAlbumId`) ?? null,
+    quality: expectNullableString(record.quality, `${indexLabel}.quality`) ?? null,
+    librarySlot: expectNullableString(record.librarySlot, `${indexLabel}.librarySlot`) ?? null,
+    status: expectNullableString(record.status, `${indexLabel}.status`) ?? null,
+    confidence: expectOptionalNumber(record.confidence, `${indexLabel}.confidence`) ?? null,
+  };
+}
+
+function parseReleaseAvailabilityContract(value: unknown, index: number): ReleaseAvailabilityContract {
+  const label = `releaseAvailability.releases[${index}]`;
+  const record = expectRecord(value, label);
+  return {
+    releaseMbid: expectString(record.releaseMbid, `${label}.releaseMbid`),
+    title: expectNullableString(record.title, `${label}.title`) ?? null,
+    disambiguation: expectNullableString(record.disambiguation, `${label}.disambiguation`) ?? null,
+    status: expectNullableString(record.status, `${label}.status`) ?? null,
+    date: expectNullableString(record.date, `${label}.date`) ?? null,
+    country: expectNullableString(record.country, `${label}.country`) ?? null,
+    format: expectNullableString(record.format, `${label}.format`) ?? null,
+    mediumCount: expectOptionalNumber(record.mediumCount, `${label}.mediumCount`) ?? null,
+    trackCount: expectOptionalNumber(record.trackCount, `${label}.trackCount`) ?? null,
+    duration: expectOptionalNumber(record.duration, `${label}.duration`) ?? null,
+    availability: expectArray(record.availability, `${label}.availability`, (item, providerIndex) =>
+      parseReleaseAvailabilityProviderContract(item, `${label}.availability[${providerIndex}]`)),
+  };
+}
+
+export function parseReleaseGroupAvailabilityContract(value: unknown): ReleaseGroupAvailabilityContract {
+  const record = expectRecord(value, "releaseAvailability");
+  const selectedRecord = expectRecord(record.selectedReleaseBySlot, "releaseAvailability.selectedReleaseBySlot");
+  const selectedReleaseBySlot: Record<string, string | null> = {};
+  for (const [slot, releaseMbid] of Object.entries(selectedRecord)) {
+    selectedReleaseBySlot[slot] = releaseMbid === null ? null : String(releaseMbid);
+  }
+
+  return {
+    releaseGroupMbid: expectString(record.releaseGroupMbid, "releaseAvailability.releaseGroupMbid"),
+    selectedReleaseBySlot,
+    releases: expectArray(record.releases, "releaseAvailability.releases", parseReleaseAvailabilityContract),
+  };
 }
 
 export function parseVideoDetailContract(value: unknown): VideoDetailContract {

--- a/api/src/database.ts
+++ b/api/src/database.ts
@@ -995,6 +995,28 @@ function ensureMusicBrainzProviderSchema(): void {
       FOREIGN KEY(release_group_mbid) REFERENCES Albums(mbid) ON DELETE CASCADE,
       FOREIGN KEY(selected_release_mbid) REFERENCES AlbumReleases(mbid) ON DELETE SET NULL
     );
+
+    -- Additive provider -> MusicBrainz match graph. Persists all candidate matches
+    -- (multiple target_mbid rows per provider source) so the release-availability
+    -- switcher can show every MB release a provider can supply. Lives alongside the
+    -- existing ProviderItems offer cache; it does not replace it.
+    CREATE TABLE IF NOT EXISTS ProviderMatches (
+      provider TEXT NOT NULL,
+      entity_type TEXT NOT NULL,          -- 'artist' | 'release' | 'recording'
+      provider_id TEXT NOT NULL,
+      provider_album_id TEXT,             -- owning provider album for recording matches
+      target_mbid TEXT NOT NULL,
+      target_kind TEXT NOT NULL,          -- mirrors entity_type
+      status TEXT,                        -- candidate | probable | verified | manual | rejected
+      confidence REAL,
+      method TEXT,
+      evidence TEXT,                      -- JSON
+      updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (provider, entity_type, provider_id, target_mbid)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_provider_matches_target ON ProviderMatches(target_mbid, entity_type);
+    CREATE INDEX IF NOT EXISTS idx_provider_matches_source ON ProviderMatches(provider, entity_type, provider_id);
   `);
 
   db.exec(`

--- a/api/src/database.ts
+++ b/api/src/database.ts
@@ -1480,6 +1480,22 @@ export function initDatabase() {
   // DEFAULT DATA
   // ====================================================================
   initializeDefaultData(migrationSummary);
+
+  // Keep the additive ProviderMatches release graph in sync with provider album
+  // offers that already carry a resolved release_mbid. Idempotent (ON CONFLICT
+  // DO NOTHING); makes existing libraries release-availability-ready without a
+  // full re-scan. New matches are written directly by the matcher.
+  db.prepare(`
+    INSERT INTO ProviderMatches (
+      provider, entity_type, provider_id, provider_album_id,
+      target_mbid, target_kind, status, confidence, method, evidence, updated_at
+    )
+    SELECT provider, 'release', provider_id, provider_id,
+           release_mbid, 'release', match_status, match_confidence, match_method, match_evidence, CURRENT_TIMESTAMP
+    FROM ProviderItems
+    WHERE entity_type = 'album' AND release_mbid IS NOT NULL AND TRIM(release_mbid) <> ''
+    ON CONFLICT(provider, entity_type, provider_id, target_mbid) DO NOTHING
+  `).run();
 }
 
 function recordDatabaseVersionState(migrationSummary: MigrationRunSummary) {

--- a/api/src/database.ts
+++ b/api/src/database.ts
@@ -1481,21 +1481,6 @@ export function initDatabase() {
   // ====================================================================
   initializeDefaultData(migrationSummary);
 
-  // Keep the additive ProviderMatches release graph in sync with provider album
-  // offers that already carry a resolved release_mbid. Idempotent (ON CONFLICT
-  // DO NOTHING); makes existing libraries release-availability-ready without a
-  // full re-scan. New matches are written directly by the matcher.
-  db.prepare(`
-    INSERT INTO ProviderMatches (
-      provider, entity_type, provider_id, provider_album_id,
-      target_mbid, target_kind, status, confidence, method, evidence, updated_at
-    )
-    SELECT provider, 'release', provider_id, provider_id,
-           release_mbid, 'release', match_status, match_confidence, match_method, match_evidence, CURRENT_TIMESTAMP
-    FROM ProviderItems
-    WHERE entity_type = 'album' AND release_mbid IS NOT NULL AND TRIM(release_mbid) <> ''
-    ON CONFLICT(provider, entity_type, provider_id, target_mbid) DO NOTHING
-  `).run();
 }
 
 function recordDatabaseVersionState(migrationSummary: MigrationRunSummary) {

--- a/api/src/routes/v1/album.ts
+++ b/api/src/routes/v1/album.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { AlbumQueryService } from "../../services/music/album-query-service.js";
 import { AlbumCommandService } from "../../services/music/album-command-service.js";
+import { getReleaseGroupAvailability } from "../../services/music/provider-matches.js";
 import {
   getObjectBody,
   getOptionalBoolean,
@@ -132,6 +133,16 @@ router.get("/:albumId/similar", (req, res) => {
 router.get("/:albumId/versions", async (req, res) => {
   try {
     res.json(await AlbumQueryService.getAlbumVersions(req.params.albumId));
+  } catch (error: any) {
+    res.status(500).json({ detail: error.message });
+  }
+});
+
+// Per-release streaming availability for a release group (release-group MBID),
+// powering the Lidarr-style release switcher. Read-only.
+router.get("/:albumId/release-availability", (req, res) => {
+  try {
+    res.json(getReleaseGroupAvailability(req.params.albumId));
   } catch (error: any) {
     res.status(500).json({ detail: error.message });
   }

--- a/api/src/routes/v1/album.ts
+++ b/api/src/routes/v1/album.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { AlbumQueryService } from "../../services/music/album-query-service.js";
 import { AlbumCommandService } from "../../services/music/album-command-service.js";
-import { getReleaseGroupAvailability } from "../../services/music/provider-matches.js";
+import { getReleaseGroupAvailability, setSlotSelection } from "../../services/music/provider-matches.js";
 import {
   getObjectBody,
   getOptionalBoolean,
@@ -144,6 +144,26 @@ router.get("/:albumId/release-availability", (req, res) => {
   try {
     res.json(getReleaseGroupAvailability(req.params.albumId));
   } catch (error: any) {
+    res.status(500).json({ detail: error.message });
+  }
+});
+
+// Switch which MB release fills a slot for this release group (the switcher write).
+router.patch("/:albumId/slots/:slot/selection", (req, res) => {
+  try {
+    const body = getObjectBody(req.body);
+    const releaseMbid = getRequiredIdentifier(body, "releaseMbid");
+    res.json(setSlotSelection({
+      releaseGroupMbid: req.params.albumId,
+      slot: req.params.slot,
+      releaseMbid,
+      provider: getOptionalString(body, "provider"),
+      providerAlbumId: getOptionalString(body, "providerAlbumId"),
+    }));
+  } catch (error: any) {
+    if (isRequestValidationError(error)) {
+      return res.status(400).json({ detail: error.message });
+    }
     res.status(500).json({ detail: error.message });
   }
 });

--- a/api/src/services/music/provider-matches.test.ts
+++ b/api/src/services/music/provider-matches.test.ts
@@ -108,3 +108,51 @@ test("getReleaseGroupAvailability reports per-release provider availability and 
   assert.ok(vinyl);
   assert.equal(vinyl.availability.length, 0);
 });
+
+test("setSlotSelection switches the selected release and derives the best provider", () => {
+  const { db } = dbModule;
+  seedReleaseGroup();
+  providerMatches.upsertProviderReleaseMatch({ provider: "tidal", providerId: "prov-stereo", releaseMbid: "rel-stereo", status: "verified", confidence: 0.95 });
+  providerMatches.upsertProviderReleaseMatch({ provider: "tidal", providerId: "prov-atmos", releaseMbid: "rel-atmos", status: "verified", confidence: 0.9 });
+
+  // No slot row yet -> setSlotSelection inserts one selecting rel-atmos for the stereo slot.
+  const after = providerMatches.setSlotSelection({ releaseGroupMbid: "rg-1", slot: "stereo", releaseMbid: "rel-atmos" });
+  assert.equal(after.selectedReleaseBySlot.stereo, "rel-atmos");
+
+  const slot = db.prepare(`SELECT selected_release_mbid, selected_provider, selected_provider_id, monitored FROM ReleaseGroupSlots WHERE release_group_mbid='rg-1' AND slot='stereo'`).get() as any;
+  assert.equal(slot.selected_release_mbid, "rel-atmos");
+  assert.equal(slot.selected_provider, "tidal");
+  assert.equal(slot.selected_provider_id, "prov-atmos"); // derived best match for rel-atmos
+  assert.equal(slot.monitored, 0); // selection does not change monitoring
+
+  // Switching again updates the existing row.
+  providerMatches.setSlotSelection({ releaseGroupMbid: "rg-1", slot: "stereo", releaseMbid: "rel-stereo", provider: "tidal", providerAlbumId: "prov-stereo" });
+  const slot2 = db.prepare(`SELECT selected_release_mbid, selected_provider_id FROM ReleaseGroupSlots WHERE release_group_mbid='rg-1' AND slot='stereo'`).get() as any;
+  assert.equal(slot2.selected_release_mbid, "rel-stereo");
+  assert.equal(slot2.selected_provider_id, "prov-stereo");
+});
+
+test("setSlotSelection rejects an unknown slot and a release outside the group", () => {
+  seedReleaseGroup();
+  assert.throws(() => providerMatches.setSlotSelection({ releaseGroupMbid: "rg-1", slot: "bogus", releaseMbid: "rel-stereo" }), /unknown slot/);
+  assert.throws(() => providerMatches.setSlotSelection({ releaseGroupMbid: "rg-1", slot: "stereo", releaseMbid: "rel-not-in-group" }), /not in release group/);
+});
+
+test("startup backfill derives ProviderMatches from existing matched provider album offers", () => {
+  const { db } = dbModule;
+  // Existing matched album offer with no ProviderMatches row (simulates a pre-existing library).
+  db.prepare(`INSERT INTO ArtistMetadata (mbid, name) VALUES ('artist-mbid-1', 'Queen')`).run();
+  db.prepare(`INSERT INTO Albums (mbid, artist_mbid, title, primary_type) VALUES ('rg-1', 'artist-mbid-1', 'A Night at the Opera', 'album')`).run();
+  db.prepare(`INSERT INTO AlbumReleases (mbid, release_group_mbid, artist_mbid, title) VALUES ('rel-stereo', 'rg-1', 'artist-mbid-1', 'A Night at the Opera')`).run();
+  db.prepare(`INSERT INTO ProviderItems (provider, entity_type, provider_id, quality, library_slot, release_group_mbid, release_mbid, match_status, match_confidence)
+              VALUES ('tidal', 'album', 'prov-stereo', 'LOSSLESS', 'stereo', 'rg-1', 'rel-stereo', 'verified', 0.95)`).run();
+  assert.equal((db.prepare(`SELECT COUNT(*) AS n FROM ProviderMatches`).get() as { n: number }).n, 0);
+
+  // Re-run init -> the idempotent backfill picks up the offer.
+  dbModule.initDatabase();
+
+  const row = db.prepare(`SELECT target_mbid, status, confidence FROM ProviderMatches WHERE provider='tidal' AND provider_id='prov-stereo' AND entity_type='release'`).get() as any;
+  assert.ok(row);
+  assert.equal(row.target_mbid, "rel-stereo");
+  assert.equal(row.status, "verified");
+});

--- a/api/src/services/music/provider-matches.test.ts
+++ b/api/src/services/music/provider-matches.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { before, beforeEach, test } from "node:test";
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "discogenius-provider-matches-"));
+process.env.DB_PATH = path.join(tempDir, "discogenius.test.db");
+process.env.DISCOGENIUS_CONFIG_DIR = tempDir;
+
+let dbModule: typeof import("../../database.js");
+let providerMatches: typeof import("./provider-matches.js");
+
+before(async () => {
+  dbModule = await import("../../database.js");
+  dbModule.initDatabase();
+  providerMatches = await import("./provider-matches.js");
+});
+
+function seedReleaseGroup() {
+  const { db } = dbModule;
+  db.prepare(`INSERT INTO ArtistMetadata (mbid, name) VALUES (?, ?)`).run("artist-mbid-1", "Queen");
+  db.prepare(`INSERT INTO Albums (mbid, artist_mbid, title, primary_type) VALUES (?, ?, ?, ?)`)
+    .run("rg-1", "artist-mbid-1", "A Night at the Opera", "album");
+  db.prepare(`INSERT INTO AlbumReleases (mbid, release_group_mbid, artist_mbid, title, date, country) VALUES (?, ?, ?, ?, ?, ?)`)
+    .run("rel-stereo", "rg-1", "artist-mbid-1", "A Night at the Opera", "1975-11-21", "GB");
+  db.prepare(`INSERT INTO AlbumReleases (mbid, release_group_mbid, artist_mbid, title, date, country) VALUES (?, ?, ?, ?, ?, ?)`)
+    .run("rel-atmos", "rg-1", "artist-mbid-1", "A Night at the Opera (Dolby Atmos)", "2022-01-01", "US");
+  // Provider album offers (ProviderItems) backing the two releases.
+  db.prepare(`INSERT INTO ProviderItems (provider, entity_type, provider_id, quality, library_slot, release_group_mbid, release_mbid)
+              VALUES ('tidal', 'album', 'prov-stereo', 'LOSSLESS', 'stereo', 'rg-1', 'rel-stereo')`).run();
+  db.prepare(`INSERT INTO ProviderItems (provider, entity_type, provider_id, quality, library_slot, release_group_mbid, release_mbid)
+              VALUES ('tidal', 'album', 'prov-atmos', 'DOLBY_ATMOS', 'spatial', 'rg-1', 'rel-atmos')`).run();
+}
+
+beforeEach(() => {
+  const { db } = dbModule;
+  for (const t of ["ProviderMatches", "ProviderItems", "ReleaseGroupSlots", "AlbumReleases", "Albums", "ArtistMetadata"]) {
+    db.prepare(`DELETE FROM ${t}`).run();
+  }
+});
+
+test("fresh database has the additive ProviderMatches table", () => {
+  const row = dbModule.db.prepare(
+    `SELECT name FROM sqlite_master WHERE type='table' AND name='ProviderMatches'`,
+  ).get() as { name?: string } | undefined;
+  assert.equal(row?.name, "ProviderMatches");
+});
+
+test("upsert persists candidate matches and dedupes per (source,target)", () => {
+  const { db } = dbModule;
+  seedReleaseGroup();
+  providerMatches.upsertProviderReleaseMatch({
+    provider: "tidal", providerId: "prov-stereo", releaseMbid: "rel-stereo",
+    status: "probable", confidence: 0.8, method: "title", evidence: JSON.stringify({ titleScore: 0.8 }),
+  });
+  // Re-upsert same source/target updates in place (no duplicate row).
+  providerMatches.upsertProviderReleaseMatch({
+    provider: "tidal", providerId: "prov-stereo", releaseMbid: "rel-stereo",
+    status: "verified", confidence: 0.99, method: "upc",
+  });
+  const rows = db.prepare(
+    `SELECT status, confidence FROM ProviderMatches WHERE provider='tidal' AND provider_id='prov-stereo' AND target_mbid='rel-stereo'`,
+  ).all() as Array<{ status: string; confidence: number }>;
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].status, "verified");
+  assert.equal(rows[0].confidence, 0.99);
+});
+
+test("a single provider album can hold multiple candidate release matches", () => {
+  const { db } = dbModule;
+  seedReleaseGroup();
+  providerMatches.upsertProviderReleaseMatch({ provider: "tidal", providerId: "prov-stereo", releaseMbid: "rel-stereo", status: "verified", confidence: 0.95 });
+  providerMatches.upsertProviderReleaseMatch({ provider: "tidal", providerId: "prov-stereo", releaseMbid: "rel-atmos", status: "candidate", confidence: 0.4 });
+  const count = (db.prepare(`SELECT COUNT(*) AS n FROM ProviderMatches WHERE provider_id='prov-stereo'`).get() as { n: number }).n;
+  assert.equal(count, 2);
+});
+
+test("getReleaseGroupAvailability reports per-release provider availability and current selection", () => {
+  const { db } = dbModule;
+  seedReleaseGroup();
+  providerMatches.upsertProviderReleaseMatch({ provider: "tidal", providerId: "prov-stereo", releaseMbid: "rel-stereo", status: "verified", confidence: 0.95 });
+  providerMatches.upsertProviderReleaseMatch({ provider: "tidal", providerId: "prov-atmos", releaseMbid: "rel-atmos", status: "verified", confidence: 0.9 });
+  db.prepare(`INSERT INTO ReleaseGroupSlots (artist_mbid, release_group_mbid, slot, monitored, selected_release_mbid)
+              VALUES ('artist-mbid-1', 'rg-1', 'stereo', 1, 'rel-stereo')`).run();
+
+  const result = providerMatches.getReleaseGroupAvailability("rg-1");
+
+  assert.equal(result.releaseGroupMbid, "rg-1");
+  assert.equal(result.releases.length, 2);
+  assert.equal(result.selectedReleaseBySlot.stereo, "rel-stereo");
+
+  const stereo = result.releases.find((r) => r.releaseMbid === "rel-stereo");
+  assert.ok(stereo);
+  assert.equal(stereo.availability.length, 1);
+  assert.equal(stereo.availability[0].provider, "tidal");
+  assert.equal(stereo.availability[0].providerAlbumId, "prov-stereo");
+  assert.equal(stereo.availability[0].quality, "LOSSLESS");
+
+  const atmos = result.releases.find((r) => r.releaseMbid === "rel-atmos");
+  assert.ok(atmos);
+  assert.equal(atmos.availability[0].quality, "DOLBY_ATMOS");
+
+  // A release in the group with no provider match still appears, with empty availability.
+  db.prepare(`INSERT INTO AlbumReleases (mbid, release_group_mbid, artist_mbid, title) VALUES ('rel-vinyl', 'rg-1', 'artist-mbid-1', 'Vinyl')`).run();
+  const withVinyl = providerMatches.getReleaseGroupAvailability("rg-1");
+  const vinyl = withVinyl.releases.find((r) => r.releaseMbid === "rel-vinyl");
+  assert.ok(vinyl);
+  assert.equal(vinyl.availability.length, 0);
+});

--- a/api/src/services/music/provider-matches.test.ts
+++ b/api/src/services/music/provider-matches.test.ts
@@ -22,10 +22,16 @@ function seedReleaseGroup() {
   db.prepare(`INSERT INTO ArtistMetadata (mbid, name) VALUES (?, ?)`).run("artist-mbid-1", "Queen");
   db.prepare(`INSERT INTO Albums (mbid, artist_mbid, title, primary_type) VALUES (?, ?, ?, ?)`)
     .run("rg-1", "artist-mbid-1", "A Night at the Opera", "album");
-  db.prepare(`INSERT INTO AlbumReleases (mbid, release_group_mbid, artist_mbid, title, date, country) VALUES (?, ?, ?, ?, ?, ?)`)
-    .run("rel-stereo", "rg-1", "artist-mbid-1", "A Night at the Opera", "1975-11-21", "GB");
+  db.prepare(`INSERT INTO AlbumReleases (mbid, release_group_mbid, artist_mbid, title, status, date, country, media_count, track_count, disambiguation) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+    .run("rel-stereo", "rg-1", "artist-mbid-1", "A Night at the Opera", "Official", "1975-11-21", "GB", 1, 12, "deluxe edition");
   db.prepare(`INSERT INTO AlbumReleases (mbid, release_group_mbid, artist_mbid, title, date, country) VALUES (?, ?, ?, ?, ?, ?)`)
     .run("rel-atmos", "rg-1", "artist-mbid-1", "A Night at the Opera (Dolby Atmos)", "2022-01-01", "US");
+  db.prepare(`INSERT INTO AlbumReleaseMedia (release_mbid, position, format, track_count) VALUES (?, 1, 'Digital Media', 12)`)
+    .run("rel-stereo");
+  db.prepare(`INSERT INTO Recordings (mbid, artist_mbid, title, length_ms) VALUES (?, ?, ?, ?)`)
+    .run("rec-1", "artist-mbid-1", "Bohemian Rhapsody", 354000);
+  db.prepare(`INSERT INTO Tracks (mbid, release_mbid, recording_mbid, title, position, medium_position, length_ms) VALUES (?, ?, ?, ?, 1, 1, ?)`)
+    .run("track-1", "rel-stereo", "rec-1", "Bohemian Rhapsody", 354000);
   // Provider album offers (ProviderItems) backing the two releases.
   db.prepare(`INSERT INTO ProviderItems (provider, entity_type, provider_id, quality, library_slot, release_group_mbid, release_mbid)
               VALUES ('tidal', 'album', 'prov-stereo', 'LOSSLESS', 'stereo', 'rg-1', 'rel-stereo')`).run();
@@ -35,7 +41,7 @@ function seedReleaseGroup() {
 
 beforeEach(() => {
   const { db } = dbModule;
-  for (const t of ["ProviderMatches", "ProviderItems", "ReleaseGroupSlots", "AlbumReleases", "Albums", "ArtistMetadata"]) {
+  for (const t of ["ProviderMatches", "ProviderItems", "ReleaseGroupSlots", "Tracks", "Recordings", "AlbumReleaseMedia", "AlbumReleases", "Albums", "ArtistMetadata"]) {
     db.prepare(`DELETE FROM ${t}`).run();
   }
 });
@@ -93,6 +99,12 @@ test("getReleaseGroupAvailability reports per-release provider availability and 
   const stereo = result.releases.find((r) => r.releaseMbid === "rel-stereo");
   assert.ok(stereo);
   assert.equal(stereo.availability.length, 1);
+  assert.equal(stereo.disambiguation, "deluxe edition");
+  assert.equal(stereo.status, "Official");
+  assert.equal(stereo.format, "Digital Media");
+  assert.equal(stereo.mediumCount, 1);
+  assert.equal(stereo.trackCount, 12);
+  assert.equal(stereo.duration, 354);
   assert.equal(stereo.availability[0].provider, "tidal");
   assert.equal(stereo.availability[0].providerAlbumId, "prov-stereo");
   assert.equal(stereo.availability[0].quality, "LOSSLESS");
@@ -132,27 +144,25 @@ test("setSlotSelection switches the selected release and derives the best provid
   assert.equal(slot2.selected_provider_id, "prov-stereo");
 });
 
+test("setSlotSelection rejects an explicit provider offer that does not match the chosen release", () => {
+  seedReleaseGroup();
+  providerMatches.upsertProviderReleaseMatch({ provider: "tidal", providerId: "prov-stereo", releaseMbid: "rel-stereo", status: "verified", confidence: 0.95 });
+  providerMatches.upsertProviderReleaseMatch({ provider: "tidal", providerId: "prov-atmos", releaseMbid: "rel-atmos", status: "verified", confidence: 0.9 });
+
+  assert.throws(
+    () => providerMatches.setSlotSelection({
+      releaseGroupMbid: "rg-1",
+      slot: "stereo",
+      releaseMbid: "rel-stereo",
+      provider: "tidal",
+      providerAlbumId: "prov-atmos",
+    }),
+    /does not match release/,
+  );
+});
+
 test("setSlotSelection rejects an unknown slot and a release outside the group", () => {
   seedReleaseGroup();
   assert.throws(() => providerMatches.setSlotSelection({ releaseGroupMbid: "rg-1", slot: "bogus", releaseMbid: "rel-stereo" }), /unknown slot/);
   assert.throws(() => providerMatches.setSlotSelection({ releaseGroupMbid: "rg-1", slot: "stereo", releaseMbid: "rel-not-in-group" }), /not in release group/);
-});
-
-test("startup backfill derives ProviderMatches from existing matched provider album offers", () => {
-  const { db } = dbModule;
-  // Existing matched album offer with no ProviderMatches row (simulates a pre-existing library).
-  db.prepare(`INSERT INTO ArtistMetadata (mbid, name) VALUES ('artist-mbid-1', 'Queen')`).run();
-  db.prepare(`INSERT INTO Albums (mbid, artist_mbid, title, primary_type) VALUES ('rg-1', 'artist-mbid-1', 'A Night at the Opera', 'album')`).run();
-  db.prepare(`INSERT INTO AlbumReleases (mbid, release_group_mbid, artist_mbid, title) VALUES ('rel-stereo', 'rg-1', 'artist-mbid-1', 'A Night at the Opera')`).run();
-  db.prepare(`INSERT INTO ProviderItems (provider, entity_type, provider_id, quality, library_slot, release_group_mbid, release_mbid, match_status, match_confidence)
-              VALUES ('tidal', 'album', 'prov-stereo', 'LOSSLESS', 'stereo', 'rg-1', 'rel-stereo', 'verified', 0.95)`).run();
-  assert.equal((db.prepare(`SELECT COUNT(*) AS n FROM ProviderMatches`).get() as { n: number }).n, 0);
-
-  // Re-run init -> the idempotent backfill picks up the offer.
-  dbModule.initDatabase();
-
-  const row = db.prepare(`SELECT target_mbid, status, confidence FROM ProviderMatches WHERE provider='tidal' AND provider_id='prov-stereo' AND entity_type='release'`).get() as any;
-  assert.ok(row);
-  assert.equal(row.target_mbid, "rel-stereo");
-  assert.equal(row.status, "verified");
 });

--- a/api/src/services/music/provider-matches.ts
+++ b/api/src/services/music/provider-matches.ts
@@ -37,8 +37,14 @@ export interface ReleaseAvailabilityProvider {
 export interface ReleaseAvailability {
   releaseMbid: string;
   title: string | null;
+  disambiguation: string | null;
+  status: string | null;
   date: string | null;
   country: string | null;
+  format: string | null;
+  mediumCount: number | null;
+  trackCount: number | null;
+  duration: number | null;
   availability: ReleaseAvailabilityProvider[];
 }
 
@@ -87,6 +93,17 @@ export interface SetSlotSelectionInput {
   providerAlbumId?: string | null;
 }
 
+interface ProviderReleaseOfferRow {
+  provider: string;
+  provider_id: string;
+  quality: string | null;
+  status: string | null;
+  confidence: number | null;
+  method: string | null;
+  evidence: string | null;
+  data: string | null;
+}
+
 /**
  * Switch which MB release fills a given slot for a release group (the write half
  * of the Lidarr-style release switcher). Selection-only: this does not change a
@@ -108,23 +125,85 @@ export function setSlotSelection(input: SetSlotSelectionInput): ReleaseGroupAvai
 
   let provider = input.provider ?? null;
   let providerAlbumId = input.providerAlbumId ?? null;
-  if (!provider || !providerAlbumId) {
-    const best = db.prepare(`
-      SELECT provider, provider_id
-      FROM ProviderMatches
-      WHERE entity_type = 'release' AND target_mbid = ?
-      ORDER BY (confidence IS NULL), confidence DESC
+  let offer: ProviderReleaseOfferRow | undefined;
+  if (provider && providerAlbumId) {
+    offer = db.prepare(`
+      SELECT
+        pm.provider,
+        pm.provider_id,
+        pi.quality,
+        pm.status,
+        pm.confidence,
+        pm.method,
+        pm.evidence,
+        pi.data
+      FROM ProviderMatches pm
+      LEFT JOIN ProviderItems pi
+        ON pi.provider = pm.provider
+       AND pi.entity_type = 'album'
+       AND CAST(pi.provider_id AS TEXT) = CAST(pm.provider_id AS TEXT)
+      WHERE pm.entity_type = 'release'
+        AND pm.target_mbid = ?
+        AND pm.provider = ?
+        AND CAST(pm.provider_id AS TEXT) = CAST(? AS TEXT)
+        AND (pm.status IS NULL OR LOWER(pm.status) <> 'rejected')
       LIMIT 1
-    `).get(input.releaseMbid) as { provider?: string; provider_id?: string } | undefined;
-    provider = provider ?? best?.provider ?? null;
-    providerAlbumId = providerAlbumId ?? best?.provider_id ?? null;
+    `).get(input.releaseMbid, provider, providerAlbumId) as ProviderReleaseOfferRow | undefined;
+    if (!offer) {
+      throw new Error(`provider offer ${provider}:${providerAlbumId} does not match release ${input.releaseMbid}`);
+    }
+  } else {
+    offer = db.prepare(`
+      SELECT
+        pm.provider,
+        pm.provider_id,
+        pi.quality,
+        pm.status,
+        pm.confidence,
+        pm.method,
+        pm.evidence,
+        pi.data
+      FROM ProviderMatches pm
+      LEFT JOIN ProviderItems pi
+        ON pi.provider = pm.provider
+       AND pi.entity_type = 'album'
+       AND CAST(pi.provider_id AS TEXT) = CAST(pm.provider_id AS TEXT)
+      WHERE pm.entity_type = 'release'
+        AND pm.target_mbid = ?
+        AND (pm.status IS NULL OR LOWER(pm.status) <> 'rejected')
+      ORDER BY (pm.confidence IS NULL), pm.confidence DESC, pm.updated_at DESC
+      LIMIT 1
+    `).get(input.releaseMbid) as ProviderReleaseOfferRow | undefined;
+    provider = provider ?? offer?.provider ?? null;
+    providerAlbumId = providerAlbumId ?? offer?.provider_id ?? null;
   }
 
   const result = db.prepare(`
     UPDATE ReleaseGroupSlots
-    SET selected_release_mbid = ?, selected_provider = ?, selected_provider_id = ?, updated_at = CURRENT_TIMESTAMP
+    SET selected_release_mbid = ?,
+        selected_provider = ?,
+        selected_provider_id = ?,
+        quality = ?,
+        match_status = ?,
+        match_confidence = ?,
+        match_method = ?,
+        match_evidence = ?,
+        provider_data = ?,
+        updated_at = CURRENT_TIMESTAMP
     WHERE release_group_mbid = ? AND slot = ?
-  `).run(input.releaseMbid, provider, providerAlbumId, input.releaseGroupMbid, input.slot);
+  `).run(
+    input.releaseMbid,
+    provider,
+    providerAlbumId,
+    offer?.quality ?? null,
+    offer?.status ?? null,
+    offer?.confidence ?? null,
+    offer?.method ?? null,
+    offer?.evidence ?? null,
+    offer?.data ?? null,
+    input.releaseGroupMbid,
+    input.slot,
+  );
 
   if (result.changes === 0) {
     const artist = db.prepare(`SELECT artist_mbid FROM Albums WHERE mbid = ?`)
@@ -135,9 +214,23 @@ export function setSlotSelection(input: SetSlotSelectionInput): ReleaseGroupAvai
     db.prepare(`
       INSERT INTO ReleaseGroupSlots (
         artist_mbid, release_group_mbid, slot, monitored,
-        selected_release_mbid, selected_provider, selected_provider_id
-      ) VALUES (?, ?, ?, 0, ?, ?, ?)
-    `).run(artist.artist_mbid, input.releaseGroupMbid, input.slot, input.releaseMbid, provider, providerAlbumId);
+        selected_release_mbid, selected_provider, selected_provider_id,
+        quality, match_status, match_confidence, match_method, match_evidence, provider_data
+      ) VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      artist.artist_mbid,
+      input.releaseGroupMbid,
+      input.slot,
+      input.releaseMbid,
+      provider,
+      providerAlbumId,
+      offer?.quality ?? null,
+      offer?.status ?? null,
+      offer?.confidence ?? null,
+      offer?.method ?? null,
+      offer?.evidence ?? null,
+      offer?.data ?? null,
+    );
   }
 
   return getReleaseGroupAvailability(input.releaseGroupMbid);
@@ -153,8 +246,33 @@ export function getReleaseGroupAvailability(releaseGroupMbid: string): ReleaseGr
     SELECT
       ar.mbid             AS release_mbid,
       ar.title            AS title,
+      ar.disambiguation   AS disambiguation,
+      ar.status           AS release_status,
       ar.date             AS date,
       ar.country          AS country,
+      ar.media_count      AS media_count,
+      ar.track_count      AS track_count,
+      (
+        SELECT GROUP_CONCAT(format_label, ', ')
+        FROM (
+          SELECT
+            CASE
+              WHEN COUNT(*) > 1 THEN CAST(COUNT(*) AS TEXT) || 'x' || COALESCE(NULLIF(TRIM(format), ''), 'Unknown')
+              ELSE COALESCE(NULLIF(TRIM(format), ''), 'Unknown')
+            END AS format_label,
+            MIN(position) AS first_position
+          FROM AlbumReleaseMedia
+          WHERE release_mbid = ar.mbid
+            AND position > 0
+          GROUP BY COALESCE(NULLIF(TRIM(format), ''), 'Unknown')
+          ORDER BY first_position
+        )
+      ) AS release_format,
+      (
+        SELECT CAST(ROUND(SUM(COALESCE(length_ms, 0)) / 1000.0) AS INTEGER)
+        FROM Tracks
+        WHERE release_mbid = ar.mbid
+      ) AS duration_seconds,
       pm.provider         AS provider,
       pm.provider_album_id AS provider_album_id,
       pm.status           AS status,
@@ -173,8 +291,14 @@ export function getReleaseGroupAvailability(releaseGroupMbid: string): ReleaseGr
   `).all(releaseGroupMbid) as Array<{
     release_mbid: string;
     title: string | null;
+    disambiguation: string | null;
+    release_status: string | null;
     date: string | null;
     country: string | null;
+    release_format: string | null;
+    media_count: number | null;
+    track_count: number | null;
+    duration_seconds: number | null;
     provider: string | null;
     provider_album_id: string | null;
     status: string | null;
@@ -187,7 +311,19 @@ export function getReleaseGroupAvailability(releaseGroupMbid: string): ReleaseGr
   for (const r of rows) {
     let rel = byRelease.get(r.release_mbid);
     if (!rel) {
-      rel = { releaseMbid: r.release_mbid, title: r.title, date: r.date, country: r.country, availability: [] };
+      rel = {
+        releaseMbid: r.release_mbid,
+        title: r.title,
+        disambiguation: r.disambiguation,
+        status: r.release_status,
+        date: r.date,
+        country: r.country,
+        format: r.release_format,
+        mediumCount: r.media_count,
+        trackCount: r.track_count,
+        duration: r.duration_seconds,
+        availability: [],
+      };
       byRelease.set(r.release_mbid, rel);
     }
     if (r.provider) {

--- a/api/src/services/music/provider-matches.ts
+++ b/api/src/services/music/provider-matches.ts
@@ -75,6 +75,74 @@ export function upsertProviderReleaseMatch(input: ProviderReleaseMatchInput): vo
   );
 }
 
+/** Library slots that can hold a selected release. */
+export const SLOTS = ["stereo", "spatial", "video"] as const;
+export type Slot = (typeof SLOTS)[number];
+
+export interface SetSlotSelectionInput {
+  releaseGroupMbid: string;
+  slot: string;
+  releaseMbid: string;
+  provider?: string | null;
+  providerAlbumId?: string | null;
+}
+
+/**
+ * Switch which MB release fills a given slot for a release group (the write half
+ * of the Lidarr-style release switcher). Selection-only: this does not change a
+ * slot's monitored / monitored_lock state — monitoring stays orthogonal. When no
+ * provider is supplied, the best (highest-confidence) matched provider offer for
+ * the chosen release is used. Returns the refreshed availability.
+ */
+export function setSlotSelection(input: SetSlotSelectionInput): ReleaseGroupAvailability {
+  if (!(SLOTS as readonly string[]).includes(input.slot)) {
+    throw new Error(`unknown slot: ${input.slot}`);
+  }
+
+  const releaseInGroup = db.prepare(
+    `SELECT 1 FROM AlbumReleases WHERE mbid = ? AND release_group_mbid = ?`,
+  ).get(input.releaseMbid, input.releaseGroupMbid);
+  if (!releaseInGroup) {
+    throw new Error(`release ${input.releaseMbid} is not in release group ${input.releaseGroupMbid}`);
+  }
+
+  let provider = input.provider ?? null;
+  let providerAlbumId = input.providerAlbumId ?? null;
+  if (!provider || !providerAlbumId) {
+    const best = db.prepare(`
+      SELECT provider, provider_id
+      FROM ProviderMatches
+      WHERE entity_type = 'release' AND target_mbid = ?
+      ORDER BY (confidence IS NULL), confidence DESC
+      LIMIT 1
+    `).get(input.releaseMbid) as { provider?: string; provider_id?: string } | undefined;
+    provider = provider ?? best?.provider ?? null;
+    providerAlbumId = providerAlbumId ?? best?.provider_id ?? null;
+  }
+
+  const result = db.prepare(`
+    UPDATE ReleaseGroupSlots
+    SET selected_release_mbid = ?, selected_provider = ?, selected_provider_id = ?, updated_at = CURRENT_TIMESTAMP
+    WHERE release_group_mbid = ? AND slot = ?
+  `).run(input.releaseMbid, provider, providerAlbumId, input.releaseGroupMbid, input.slot);
+
+  if (result.changes === 0) {
+    const artist = db.prepare(`SELECT artist_mbid FROM Albums WHERE mbid = ?`)
+      .get(input.releaseGroupMbid) as { artist_mbid?: string } | undefined;
+    if (!artist?.artist_mbid) {
+      throw new Error(`unknown release group ${input.releaseGroupMbid}`);
+    }
+    db.prepare(`
+      INSERT INTO ReleaseGroupSlots (
+        artist_mbid, release_group_mbid, slot, monitored,
+        selected_release_mbid, selected_provider, selected_provider_id
+      ) VALUES (?, ?, ?, 0, ?, ?, ?)
+    `).run(artist.artist_mbid, input.releaseGroupMbid, input.slot, input.releaseMbid, provider, providerAlbumId);
+  }
+
+  return getReleaseGroupAvailability(input.releaseGroupMbid);
+}
+
 /**
  * Read: per-release streaming availability for a MusicBrainz release group.
  * Lists every MB release in the group, with the providers that have a matched

--- a/api/src/services/music/provider-matches.ts
+++ b/api/src/services/music/provider-matches.ts
@@ -1,0 +1,148 @@
+import { db } from "../../database.js";
+
+/**
+ * Additive provider -> MusicBrainz match graph (the `ProviderMatches` table).
+ *
+ * This persists candidate matches from a provider entity (today: a provider album)
+ * to a canonical MusicBrainz entity (today: an MB release). Multiple candidate rows
+ * per provider source are allowed, which is what lets the release-availability
+ * switcher show every MB release a provider can supply. It lives alongside the
+ * existing `ProviderItems` offer cache and does not replace it.
+ */
+
+export interface ProviderReleaseMatchInput {
+  provider: string;
+  /** Provider album id (the match source). */
+  providerId: string;
+  /** Owning provider album id; for a release match this equals providerId. */
+  providerAlbumId?: string | null;
+  /** Target MusicBrainz release MBID. */
+  releaseMbid: string;
+  status?: string | null;
+  confidence?: number | null;
+  method?: string | null;
+  /** Pre-serialized JSON evidence. */
+  evidence?: string | null;
+}
+
+export interface ReleaseAvailabilityProvider {
+  provider: string;
+  providerAlbumId: string | null;
+  quality: string | null;
+  librarySlot: string | null;
+  status: string | null;
+  confidence: number | null;
+}
+
+export interface ReleaseAvailability {
+  releaseMbid: string;
+  title: string | null;
+  date: string | null;
+  country: string | null;
+  availability: ReleaseAvailabilityProvider[];
+}
+
+export interface ReleaseGroupAvailability {
+  releaseGroupMbid: string;
+  /** slot name -> selected release MBID (from ReleaseGroupSlots). */
+  selectedReleaseBySlot: Record<string, string | null>;
+  releases: ReleaseAvailability[];
+}
+
+/** Additively upsert a provider-album -> MB-release match candidate. */
+export function upsertProviderReleaseMatch(input: ProviderReleaseMatchInput): void {
+  db.prepare(`
+    INSERT INTO ProviderMatches (
+      provider, entity_type, provider_id, provider_album_id,
+      target_mbid, target_kind, status, confidence, method, evidence, updated_at
+    ) VALUES (?, 'release', ?, ?, ?, 'release', ?, ?, ?, ?, CURRENT_TIMESTAMP)
+    ON CONFLICT(provider, entity_type, provider_id, target_mbid) DO UPDATE SET
+      provider_album_id = excluded.provider_album_id,
+      status = excluded.status,
+      confidence = excluded.confidence,
+      method = excluded.method,
+      evidence = excluded.evidence,
+      updated_at = CURRENT_TIMESTAMP
+  `).run(
+    input.provider,
+    String(input.providerId),
+    input.providerAlbumId != null ? String(input.providerAlbumId) : String(input.providerId),
+    input.releaseMbid,
+    input.status ?? null,
+    input.confidence ?? null,
+    input.method ?? null,
+    input.evidence ?? null,
+  );
+}
+
+/**
+ * Read: per-release streaming availability for a MusicBrainz release group.
+ * Lists every MB release in the group, with the providers that have a matched
+ * provider album for it, plus which release is currently selected per slot.
+ */
+export function getReleaseGroupAvailability(releaseGroupMbid: string): ReleaseGroupAvailability {
+  const rows = db.prepare(`
+    SELECT
+      ar.mbid             AS release_mbid,
+      ar.title            AS title,
+      ar.date             AS date,
+      ar.country          AS country,
+      pm.provider         AS provider,
+      pm.provider_album_id AS provider_album_id,
+      pm.status           AS status,
+      pm.confidence       AS confidence,
+      pi.quality          AS quality,
+      pi.library_slot     AS library_slot
+    FROM AlbumReleases ar
+    LEFT JOIN ProviderMatches pm
+      ON pm.entity_type = 'release' AND pm.target_mbid = ar.mbid
+    LEFT JOIN ProviderItems pi
+      ON pi.provider = pm.provider
+     AND pi.entity_type = 'album'
+     AND CAST(pi.provider_id AS TEXT) = CAST(pm.provider_id AS TEXT)
+    WHERE ar.release_group_mbid = ?
+    ORDER BY (ar.date IS NULL), ar.date, ar.mbid, pm.confidence DESC
+  `).all(releaseGroupMbid) as Array<{
+    release_mbid: string;
+    title: string | null;
+    date: string | null;
+    country: string | null;
+    provider: string | null;
+    provider_album_id: string | null;
+    status: string | null;
+    confidence: number | null;
+    quality: string | null;
+    library_slot: string | null;
+  }>;
+
+  const byRelease = new Map<string, ReleaseAvailability>();
+  for (const r of rows) {
+    let rel = byRelease.get(r.release_mbid);
+    if (!rel) {
+      rel = { releaseMbid: r.release_mbid, title: r.title, date: r.date, country: r.country, availability: [] };
+      byRelease.set(r.release_mbid, rel);
+    }
+    if (r.provider) {
+      rel.availability.push({
+        provider: r.provider,
+        providerAlbumId: r.provider_album_id,
+        quality: r.quality,
+        librarySlot: r.library_slot,
+        status: r.status,
+        confidence: r.confidence,
+      });
+    }
+  }
+
+  const slotRows = db.prepare(`
+    SELECT slot, selected_release_mbid FROM ReleaseGroupSlots WHERE release_group_mbid = ?
+  `).all(releaseGroupMbid) as Array<{ slot: string; selected_release_mbid: string | null }>;
+  const selectedReleaseBySlot: Record<string, string | null> = {};
+  for (const s of slotRows) selectedReleaseBySlot[s.slot] = s.selected_release_mbid ?? null;
+
+  return {
+    releaseGroupMbid,
+    selectedReleaseBySlot,
+    releases: Array.from(byRelease.values()),
+  };
+}

--- a/api/src/services/music/refresh-album-service.ts
+++ b/api/src/services/music/refresh-album-service.ts
@@ -10,6 +10,7 @@ import type { ProviderAlbum, ProviderTrack } from "../providers/streaming-provid
 import { isSpatialAudioQuality } from "../../utils/spatial-audio.js";
 import { ProviderArtistIdentityService, type ProviderArtistIdentityInput } from "../metadata/provider-artist-identity-service.js";
 import { ProviderOfferReleaseLinkService } from "../metadata/provider-offer-release-link-service.js";
+import { upsertProviderReleaseMatch } from "./provider-matches.js";
 
 type SimilarAlbumSeed = {
     albumId: string;
@@ -923,6 +924,22 @@ export class RefreshAlbumService {
                 quality: album.quality || null,
             }),
         );
+
+        // Additive: also persist the provider album -> MB release match into the
+        // ProviderMatches candidate graph (powers the release-availability switcher).
+        // The ProviderItems offer write above is unchanged.
+        if (matchedReleaseMbid) {
+            upsertProviderReleaseMatch({
+                provider: "tidal",
+                providerId: String(album.provider_id),
+                providerAlbumId: String(album.provider_id),
+                releaseMbid: matchedReleaseMbid,
+                status: releaseGroupMatch?.status ?? null,
+                confidence: releaseGroupMatch?.confidence ?? null,
+                method: releaseGroupMatch?.method ?? null,
+                evidence: releaseGroupMatch ? JSON.stringify(releaseGroupMatch.evidence) : null,
+            });
+        }
 
         this.storeCanonicalAlbumSupplements({
             releaseGroupMbid: matchedReleaseGroup?.mbid || null,

--- a/api/src/services/music/release-group-slot-service.test.ts
+++ b/api/src/services/music/release-group-slot-service.test.ts
@@ -477,6 +477,18 @@ test("provider slot selection can bind stereo and Atmos to different releases an
     { slot: "stereo", selected_provider_id: "provider-slot-stereo", selected_release_mbid: stereoReleaseMbid },
   ]);
 
+  const matchRows = db.prepare(`
+    SELECT provider_id, target_mbid, status
+    FROM ProviderMatches
+    WHERE provider = 'tidal' AND entity_type = 'release'
+      AND provider_id IN ('provider-slot-atmos', 'provider-slot-stereo')
+    ORDER BY provider_id
+  `).all() as Array<{ provider_id: string; target_mbid: string; status: string }>;
+  assert.deepEqual(matchRows, [
+    { provider_id: "provider-slot-atmos", target_mbid: atmosReleaseMbid, status: "verified" },
+    { provider_id: "provider-slot-stereo", target_mbid: stereoReleaseMbid, status: "verified" },
+  ]);
+
   const albumEvidence = db.prepare(`
     SELECT provider_id, upc, library_slot, release_mbid
     FROM ProviderItems

--- a/api/src/services/music/release-group-slot-service.ts
+++ b/api/src/services/music/release-group-slot-service.ts
@@ -4,6 +4,7 @@ import type { ProviderReleaseGroupMatch } from "../metadata/provider-release-gro
 import { isSpatialAudioQuality, normalizeQualityTag } from "../../utils/spatial-audio.js";
 import { scoreTrackMatch as sharedScoreTrackMatch, TRACK_MATCH_THRESHOLD } from "./provider-track-matcher.js";
 import { MusicBrainzReleaseSelectionService } from "../metadata/musicbrainz-release-selection-service.js";
+import { upsertProviderReleaseMatch } from "./provider-matches.js";
 
 export type ReleaseGroupLibrarySlot = "stereo" | "spatial";
 
@@ -836,6 +837,18 @@ export class ReleaseGroupSlotService {
                     JSON.stringify({ ...selection.match.evidence, score: selection.score }),
                     JSON.stringify(buildProviderOfferSnapshot(selection.album)),
                 );
+                if (selection.match.releaseMbid) {
+                    upsertProviderReleaseMatch({
+                        provider: selection.provider,
+                        providerId: selection.album.providerId,
+                        providerAlbumId: selection.album.providerId,
+                        releaseMbid: selection.match.releaseMbid,
+                        status: selection.match.status,
+                        confidence: selection.match.confidence,
+                        method: selection.match.method,
+                        evidence: JSON.stringify({ ...selection.match.evidence, score: selection.score }),
+                    });
+                }
                 counts[selection.slot] += 1;
             }
         })();

--- a/app/src/hooks/useAlbumPage.ts
+++ b/app/src/hooks/useAlbumPage.ts
@@ -10,12 +10,14 @@ import {
 import type {
     AlbumTrackContract as AlbumTrack,
     AlbumVersionContract as AlbumVersion,
+    ReleaseGroupAvailabilityContract as ReleaseGroupAvailability,
     SimilarAlbumContract as SimilarAlbum,
 } from '@contracts/media';
 
 export type {
     AlbumTrackContract as AlbumTrack,
     AlbumVersionContract as AlbumVersion,
+    ReleaseGroupAvailabilityContract as ReleaseGroupAvailability,
     SimilarAlbumContract as SimilarAlbum,
 } from '@contracts/media';
 
@@ -24,6 +26,7 @@ export interface AlbumPageData {
     tracks: AlbumTrack[];
     similarAlbums: SimilarAlbum[];
     otherVersions: AlbumVersion[];
+    releaseAvailability: ReleaseGroupAvailability | null;
     artistImage: string | null;
 }
 
@@ -44,10 +47,16 @@ export function useAlbumPage(albumId: string | undefined) {
                 throw new Error('Album ID is required');
             }
 
-            const response = await api.getAlbumPage(albumId, {
-                signal,
-                timeoutMs: 15_000,
-            });
+            const [response, releaseAvailability] = await Promise.all([
+                api.getAlbumPage(albumId, {
+                    signal,
+                    timeoutMs: 15_000,
+                }),
+                api.getAlbumReleaseAvailability(albumId, {
+                    signal,
+                    timeoutMs: 15_000,
+                }),
+            ]);
 
             const artistImage = response.artistPicture ?? response.artistCoverImageUrl ?? null;
 
@@ -56,6 +65,7 @@ export function useAlbumPage(albumId: string | undefined) {
                 tracks: response.tracks,
                 otherVersions: response.otherVersions,
                 similarAlbums: response.similarAlbums,
+                releaseAvailability,
                 artistImage,
             };
         },

--- a/app/src/pages/AlbumPage.tsx
+++ b/app/src/pages/AlbumPage.tsx
@@ -1,11 +1,13 @@
 import { Fragment, useState, useCallback, useMemo, useLayoutEffect, useRef, useEffect } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { useQueryClient, useQuery } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { formatDurationSeconds } from "@/utils/format";
 import {
   AvatarGroup,
   AvatarGroupItem,
+  Badge,
   Button,
+  Card,
   Text,
   Title1,
   Title2,
@@ -48,6 +50,7 @@ import {
   useAlbumPage,
   type AlbumPageData,
   type AlbumTrack,
+  type ReleaseGroupAvailability,
 } from "@/hooks/useAlbumPage";
 import { useMonitoring } from "@/hooks/useMonitoring";
 import { useTrackQueueActions } from "@/hooks/useTrackQueueActions";
@@ -439,6 +442,72 @@ const useStyles = makeStyles({
     alignItems: "center",
     gap: tokens.spacingHorizontalS,
   },
+  releaseSwitcher: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalS,
+    width: "100%",
+  },
+  releaseRow: {
+    display: "grid",
+    gridTemplateColumns: "minmax(0, 1fr)",
+    gap: tokens.spacingVerticalS,
+    paddingTop: tokens.spacingVerticalM,
+    paddingRight: tokens.spacingHorizontalM,
+    paddingBottom: tokens.spacingVerticalM,
+    paddingLeft: tokens.spacingHorizontalM,
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackgroundAlpha2,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStrokeAlpha2}`,
+    "@media (min-width: 820px)": {
+      gridTemplateColumns: "minmax(0, 1fr) auto",
+      alignItems: "center",
+      gap: tokens.spacingHorizontalL,
+    },
+  },
+  releaseMain: {
+    minWidth: 0,
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+  },
+  releaseTitleRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: tokens.spacingHorizontalS,
+    flexWrap: "wrap",
+  },
+  releaseTitle: {
+    minWidth: 0,
+    overflowWrap: "anywhere",
+  },
+  releaseMeta: {
+    display: "flex",
+    alignItems: "center",
+    gap: tokens.spacingHorizontalS,
+    flexWrap: "wrap",
+    color: tokens.colorNeutralForeground2,
+  },
+  releaseAvailability: {
+    display: "flex",
+    alignItems: "center",
+    gap: tokens.spacingHorizontalS,
+    flexWrap: "wrap",
+  },
+  releaseSlotActions: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    gap: tokens.spacingHorizontalS,
+    flexWrap: "wrap",
+    "@media (min-width: 820px)": {
+      justifyContent: "flex-end",
+      flexWrap: "nowrap",
+    },
+  },
+  unavailableText: {
+    color: tokens.colorNeutralForeground3,
+  },
   lockColorRed: {
     color: tokens.colorPaletteRedForeground1,
   },
@@ -481,6 +550,196 @@ const useStyles = makeStyles({
 /* ── Album overflow helpers ─────────────────────────────────── */
 
 const EMPTY_ALBUM_TRACKS: AlbumTrack[] = [];
+const SWITCHABLE_SLOTS = ["stereo", "spatial"] as const;
+type SwitchableSlot = (typeof SWITCHABLE_SLOTS)[number];
+
+function slotLabel(slot: SwitchableSlot): string {
+  return slot === "spatial" ? "Spatial" : "Stereo";
+}
+
+function providerDisplayName(provider?: string | null): string {
+  const normalized = String(provider || "").trim().toLowerCase();
+  if (!normalized) return "Provider";
+  if (normalized === "tidal") return "TIDAL";
+  if (normalized.startsWith("apple")) return "Apple Music";
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+function releaseYear(date?: string | null): string | null {
+  if (!date) return null;
+  const year = new Date(date).getFullYear();
+  return Number.isFinite(year) ? String(year) : date.slice(0, 4) || null;
+}
+
+function releaseCountryLabel(country?: string | null): string | null {
+  const text = String(country || "").trim();
+  if (!text || text === "[]") return null;
+  if (text.startsWith("[") && text.endsWith("]")) {
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map((item) => String(item || "").replace(/^\[|\]$/g, "").trim())
+          .filter(Boolean)
+          .join(", ") || null;
+      }
+    } catch {
+      return text;
+    }
+  }
+  return text.replace(/^\[|\]$/g, "").trim() || null;
+}
+
+function releaseDisambiguationLabel(disambiguation?: string | null): string | null {
+  const text = String(disambiguation || "").trim();
+  if (!text) return null;
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function releaseCountLabel(count: number | null | undefined, singular: string, plural: string): string | null {
+  if (count == null || !Number.isFinite(count) || count <= 0) return null;
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function releaseStatusLabel(status?: string | null): string | null {
+  const text = String(status || "").trim();
+  if (!text || text.toLowerCase() === "official") return null;
+  return text;
+}
+
+function releaseMetaParts(release: ReleaseGroupAvailability["releases"][number]): string[] {
+  return [
+    releaseYear(release.date),
+    releaseCountryLabel(release.country),
+    releaseCountLabel(release.mediumCount, "medium", "media"),
+    releaseCountLabel(release.trackCount, "track", "tracks"),
+    release.format ? `[${release.format}]` : null,
+    release.duration ? formatDurationSeconds(release.duration) : null,
+    releaseStatusLabel(release.status),
+  ].filter((part): part is string => Boolean(part));
+}
+
+function isSpatialQuality(quality?: string | null): boolean {
+  const normalized = String(quality || "").toUpperCase();
+  return normalized.includes("ATMOS") || normalized.includes("SPATIAL") || normalized.includes("360");
+}
+
+function chooseAvailabilityForSlot(
+  release: ReleaseGroupAvailability["releases"][number],
+  slot: SwitchableSlot,
+): ReleaseGroupAvailability["releases"][number]["availability"][number] | null {
+  const exact = release.availability.find((offer) => String(offer.librarySlot || "").toLowerCase() === slot);
+  if (exact) return exact;
+  if (slot === "spatial") {
+    return release.availability.find((offer) => isSpatialQuality(offer.quality)) ?? null;
+  }
+  return release.availability.find((offer) => !isSpatialQuality(offer.quality)) ?? release.availability[0] ?? null;
+}
+
+interface ReleaseSwitcherProps {
+  availability: ReleaseGroupAvailability;
+  currentReleaseMbid?: string | null;
+  pendingSelectionKey?: string | null;
+  onSelect: (slot: SwitchableSlot, releaseMbid: string, offer: ReleaseGroupAvailability["releases"][number]["availability"][number]) => void;
+}
+
+function ReleaseSwitcher({
+  availability,
+  currentReleaseMbid,
+  pendingSelectionKey,
+  onSelect,
+}: ReleaseSwitcherProps) {
+  const styles = useStyles();
+  const releases = availability.releases;
+
+  if (releases.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.releaseSwitcher}>
+      {releases.map((release) => {
+        const disambiguation = releaseDisambiguationLabel(release.disambiguation);
+        const metaParts = releaseMetaParts(release);
+        const selectedSlots = SWITCHABLE_SLOTS.filter((slot) => availability.selectedReleaseBySlot[slot] === release.releaseMbid);
+        const providerOffers = Array.from(release.availability.reduce((deduped, offer) => {
+          const slot = String(offer.librarySlot || "").toLowerCase();
+          if (slot !== "stereo" && slot !== "spatial") {
+            return deduped;
+          }
+          const key = `${offer.provider || ""}|${slot}|${offer.quality || ""}`;
+          if (!deduped.has(key)) {
+            deduped.set(key, {
+              slot,
+              quality: offer.quality,
+              provider: offer.provider,
+              matchStatus: offer.status,
+              providerAlbumId: offer.providerAlbumId,
+              selectedReleaseMbid: release.releaseMbid,
+            } satisfies ProviderQualityOffer);
+          }
+          return deduped;
+        }, new Map<string, ProviderQualityOffer>()).values());
+
+        return (
+          <Card key={release.releaseMbid} className={styles.releaseRow}>
+            <div className={styles.releaseMain}>
+              <div className={styles.releaseTitleRow}>
+                <Text weight="semibold" className={styles.releaseTitle}>
+                  {release.title || "Untitled release"}
+                </Text>
+                {disambiguation ? (
+                  <Badge appearance="outline" color="subtle">{disambiguation}</Badge>
+                ) : null}
+                {release.releaseMbid === currentReleaseMbid ? (
+                  <Badge appearance="outline" color="subtle">Current page</Badge>
+                ) : null}
+                {selectedSlots.map((slot) => (
+                  <Badge key={slot} appearance="tint" color="success">{slotLabel(slot)}</Badge>
+                ))}
+              </div>
+              <div className={styles.releaseMeta}>
+                {metaParts.length > 0 ? <Text size={200}>{metaParts.join(" · ")}</Text> : null}
+                <Tooltip content={release.releaseMbid} relationship="label">
+                  <Text size={100}>{release.releaseMbid}</Text>
+                </Tooltip>
+              </div>
+              <div className={styles.releaseAvailability}>
+                {providerOffers.length > 0 ? (
+                  <ProviderQualityRow offers={providerOffers} size="small" />
+                ) : (
+                  <Text size={200} className={styles.unavailableText}>No matched provider offer</Text>
+                )}
+              </div>
+            </div>
+            <div className={styles.releaseSlotActions}>
+              {SWITCHABLE_SLOTS.map((slot) => {
+                const offer = chooseAvailabilityForSlot(release, slot);
+                const selected = availability.selectedReleaseBySlot[slot] === release.releaseMbid;
+                const pending = pendingSelectionKey === `${slot}:${release.releaseMbid}`;
+                const disabled = !offer || selected || Boolean(pendingSelectionKey);
+                const providerName = providerDisplayName(offer?.provider);
+                const buttonLabel = selected ? `${slotLabel(slot)} selected` : `Use for ${slotLabel(slot)}`;
+                return (
+                  <Button
+                    key={slot}
+                    size="small"
+                    appearance={selected ? "primary" : "secondary"}
+                    disabled={disabled}
+                    onClick={() => offer ? onSelect(slot, release.releaseMbid, offer) : undefined}
+                    title={offer ? `${buttonLabel} from ${providerName}` : `No ${slotLabel(slot).toLowerCase()} offer for this release`}
+                  >
+                    {pending ? "Saving..." : buttonLabel}
+                  </Button>
+                );
+              })}
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
 
 const AlbumPage = () => {
   const styles = useStyles();
@@ -498,6 +757,7 @@ const AlbumPage = () => {
   const [coverInfoOpen, setCoverInfoOpen] = useState(false);
   const [coverImageFailed, setCoverImageFailed] = useState(false);
   const [providerCoverImageFailed, setProviderCoverImageFailed] = useState(false);
+  const [pendingSelectionKey, setPendingSelectionKey] = useState<string | null>(null);
   const handledTrackScrollKeyRef = useRef<string | null>(null);
 
   const { data: pageData, isLoading: loading, error, refetch } = useAlbumPage(albumId);
@@ -530,6 +790,7 @@ const AlbumPage = () => {
       .map(({ item }) => item);
   }, [pageData?.similarAlbums]);
   const otherVersions = pageData?.otherVersions ?? [];
+  const releaseAvailability = pageData?.releaseAvailability ?? null;
   const artistImage = pageData?.artistImage ?? undefined;
   const albumArtists = album?.album_artists?.length
     ? album.album_artists
@@ -758,6 +1019,60 @@ const AlbumPage = () => {
     }));
     dispatchLibraryUpdated();
   };
+
+  const slotSelectionMutation = useMutation({
+    mutationFn: async ({
+      slot,
+      releaseMbid,
+      provider,
+      providerAlbumId,
+    }: {
+      slot: SwitchableSlot;
+      releaseMbid: string;
+      provider: string;
+      providerAlbumId: string;
+    }) => api.setAlbumSlotSelection(albumId!, slot, { releaseMbid, provider, providerAlbumId }),
+    onSuccess: async (releaseAvailability) => {
+      updateAlbumPageCache((current) => ({
+        ...current,
+        releaseAvailability,
+      }));
+      await queryClient.invalidateQueries({ queryKey: albumPageQueryKey(albumId) });
+      dispatchLibraryUpdated();
+      toast({
+        title: "Release selection updated",
+        description: "The selected provider offer has been switched for this library.",
+      });
+    },
+    onError: (mutationError) => {
+      toast({
+        title: "Failed to switch release",
+        description: mutationError instanceof Error ? mutationError.message : "Please try again",
+        variant: "destructive",
+      });
+    },
+    onSettled: () => {
+      setPendingSelectionKey(null);
+    },
+  });
+
+  const handleSelectReleaseForSlot = useCallback((
+    slot: SwitchableSlot,
+    releaseMbid: string,
+    offer: ReleaseGroupAvailability["releases"][number]["availability"][number],
+  ) => {
+    if (!albumId || !offer.providerAlbumId) {
+      return;
+    }
+
+    setPendingSelectionKey(`${slot}:${releaseMbid}`);
+    slotSelectionMutation.mutate({
+      slot,
+      releaseMbid,
+      provider: offer.provider,
+      providerAlbumId: offer.providerAlbumId,
+    });
+  }, [albumId, slotSelectionMutation]);
 
   const handleDownloadAlbum = async (slot?: 'stereo' | 'spatial') => {
     if (!album || !hasAnyProviderOffer) return;
@@ -1169,29 +1484,39 @@ const AlbumPage = () => {
         })()}
 
         {/* Release Group Releases Section */}
-        {
-          otherVersions.length > 0 && (
-            <div className={styles.sectionSpacing}>
-              <div className={styles.sectionHeader}>
-                <Title2>Other releases</Title2>
-              </div>
-              <div className={styles.carousel}>
-                {otherVersions.map((version) => {
-                  const year = version.release_date ? new Date(version.release_date).getFullYear() : '';
-                  const isSelectedEdition = Boolean(version.id) && [
-                    album.stereo_release_mbid,
-                    album.spatial_release_mbid,
-                    album.selected_release_mbid,
-                  ].includes(version.id);
-                  const subtitle = [isSelectedEdition ? 'Selected edition' : null, version.version, year]
-                    .filter(Boolean)
-                    .join(' · ');
-                  return renderMiniAlbumCard(version, subtitle, undefined, { to: null });
-                })}
-              </div>
+        {releaseAvailability && releaseAvailability.releases.length > 0 ? (
+          <div className={styles.sectionSpacing}>
+            <div className={styles.sectionHeader}>
+              <Title2>Releases</Title2>
             </div>
-          )
-        }
+            <ReleaseSwitcher
+              availability={releaseAvailability}
+              currentReleaseMbid={album.selected_release_mbid || album.stereo_release_mbid || album.spatial_release_mbid}
+              pendingSelectionKey={pendingSelectionKey}
+              onSelect={handleSelectReleaseForSlot}
+            />
+          </div>
+        ) : otherVersions.length > 0 ? (
+          <div className={styles.sectionSpacing}>
+            <div className={styles.sectionHeader}>
+              <Title2>Other releases</Title2>
+            </div>
+            <div className={styles.carousel}>
+              {otherVersions.map((version) => {
+                const year = version.release_date ? new Date(version.release_date).getFullYear() : '';
+                const isSelectedEdition = Boolean(version.id) && [
+                  album.stereo_release_mbid,
+                  album.spatial_release_mbid,
+                  album.selected_release_mbid,
+                ].includes(version.id);
+                const subtitle = [isSelectedEdition ? 'Selected edition' : null, version.version, year]
+                  .filter(Boolean)
+                  .join(' · ');
+                return renderMiniAlbumCard(version, subtitle, undefined, { to: null });
+              })}
+            </div>
+          </div>
+        ) : null}
 
         {/* Similar Albums Section */}
         {

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -44,6 +44,7 @@ import type {
   AlbumTrackContract,
   AlbumVersionContract,
   LibraryFilesListResponseContract,
+  ReleaseGroupAvailabilityContract,
   SimilarAlbumContract,
   VideoDetailContract,
   VideoUpdateContract,
@@ -52,6 +53,7 @@ import {
   parseAlbumTracksContract,
   parseAlbumVersionsContract,
   parseLibraryFilesListResponseContract,
+  parseReleaseGroupAvailabilityContract,
   parseSimilarAlbumsContract,
   parseVideoDetailContract,
 } from '@contracts/media';
@@ -709,6 +711,21 @@ class ApiClient {
 
   async getAlbumVersions(albumId: string, options: RequestControlOptions = {}): Promise<AlbumVersionContract[]> {
     return this.request(`/v1/album/${albumId}/versions`, options, parseAlbumVersionsContract);
+  }
+
+  async getAlbumReleaseAvailability(albumId: string, options: RequestControlOptions = {}): Promise<ReleaseGroupAvailabilityContract> {
+    return this.request(`/v1/album/${albumId}/release-availability`, options, parseReleaseGroupAvailabilityContract);
+  }
+
+  async setAlbumSlotSelection(albumId: string, slot: string, input: {
+    releaseMbid: string;
+    provider?: string | null;
+    providerAlbumId?: string | null;
+  }): Promise<ReleaseGroupAvailabilityContract> {
+    return this.request(`/v1/album/${albumId}/slots/${slot}/selection`, {
+      method: 'PATCH',
+      body: JSON.stringify(input),
+    }, parseReleaseGroupAvailabilityContract);
   }
 
   async getTracks(params?: {


### PR DESCRIPTION
## Summary
- Adds the additive `ProviderMatches` table as the provider-offer to MusicBrainz-release match graph.
- Writes release matches during normal provider album refresh and release-group slot sync; no startup backfill or backwards-compat migration path is kept because runtime DBs are reset for this transition.
- Adds release availability read/write endpoints for album pages, including validated slot selection and provider-offer binding.
- Adds a Fluent UI release switcher on album pages with Lidarr-style release details: disambiguation, country, medium count, track count, format, duration, current-page marker, and selected slot badges.
- Keeps provider data scoped to availability/download evidence; MusicBrainz/SkyHook remains the catalog source of truth.

## Validation
- `yarn --cwd api build`
- `yarn --cwd app typecheck`
- `yarn --cwd api tsx --test src/services/music/provider-matches.test.ts`
- `yarn --cwd api tsx --test src/services/music/release-group-slot-service.test.ts`
- `yarn ci`
- `docker compose up -d --build`
- Fresh Docker DB verified inside container: schema version 29, `ProviderMatches` table present.
- In-app browser QA on deployed container at `http://localhost:3737`: Bastille/real provider-token flow, album release switcher desktop and mobile visual pass, no console errors.

## Notes
- The earlier startup ProviderMatches backfill was removed intentionally. Backfill would only serve pre-existing databases; this transition expects runtime data to be wiped while preserving `config.toml` and provider tokens.
- Lidarr reference checked in `.ref_lidarr`: `AlbumReleaseSelectInputConnector.js` and `AlbumReleaseResource.cs` for the release details shown in the selector.