### PR TITLE
Share one /api/v1/stats query between Library and Dashboard

### DIFF
--- a/app/src/hooks/useLibrary.ts
+++ b/app/src/hooks/useLibrary.ts
@@ -14,7 +14,9 @@ type SortKey = "name" | "releaseDate" | "popularity" | "scannedAt";
 type SortDir = "asc" | "desc";
 type ActiveLibraryTab = "artists" | "albums" | "tracks" | "videos";
 
-const LIBRARY_STATS_QUERY_KEY = ["libraryStats"] as const;
+// Shared so the Dashboard reuses the same cached /api/v1/stats result instead of
+// fetching the identical snapshot under its own key.
+export const LIBRARY_STATS_QUERY_KEY = ["libraryStats"] as const;
 const LIBRARY_STATS_GLOBAL_EVENTS = [
   "artist.scanned",
   "artist.refresh.completed",

--- a/app/src/pages/dashboard/Dashboard.tsx
+++ b/app/src/pages/dashboard/Dashboard.tsx
@@ -35,6 +35,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/services/api";
 import type { LibraryStats } from "@/hooks/useLibrary";
+import { LIBRARY_STATS_QUERY_KEY } from "@/hooks/useLibrary";
 import { useToast } from "@/hooks/useToast";
 import { useQueueStatus } from "@/hooks/useQueueStatus";
 import { useDebouncedQueryInvalidation } from "@/hooks/useDebouncedQueryInvalidation";
@@ -281,8 +282,6 @@ const useStyles = makeStyles({
     },
 });
 
-const dashboardStatsQueryKey = ["dashboardStats"] as const;
-
 const DASHBOARD_TAB_STORAGE_KEY = "discogenius:dashboard-tab";
 let hasConsumedDashboardReloadState = false;
 
@@ -333,15 +332,16 @@ const Dashboard = () => {
         hasStatusData,
     } = useStatusOverview();
     useDebouncedQueryInvalidation({
-        queryKeys: [dashboardStatsQueryKey],
+        queryKeys: [LIBRARY_STATS_QUERY_KEY],
         globalEvents: ["file.added", "file.deleted", "file.upgraded", "config.updated"],
         windowEvents: [LIBRARY_UPDATED_EVENT, ACTIVITY_REFRESH_EVENT],
         debounceMs: 500,
     });
 
     const statsQuery = useQuery<LibraryStats | null>({
-        queryKey: dashboardStatsQueryKey,
-        queryFn: async (): Promise<LibraryStats | null> => await api.getStats() as LibraryStats,
+        // Shared key with the Library page: one cached /api/v1/stats fetch serves both.
+        queryKey: LIBRARY_STATS_QUERY_KEY,
+        queryFn: ({ signal }): Promise<LibraryStats | null> => api.getStats({ signal, timeoutMs: 8_000 }) as Promise<LibraryStats | null>,
         staleTime: 30_000,
         refetchOnWindowFocus: false,
         retry: 1,


### PR DESCRIPTION
Both pages display library stats but fetched/cached the identical `/api/v1/stats` snapshot under separate React Query keys. Unified onto the shared `LIBRARY_STATS_QUERY_KEY` so it's fetched once and reused across navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)